### PR TITLE
Load answers for checking if qualified

### DIFF
--- a/Application/JobApps/Queries/GetAllJobAppsQuery.cs
+++ b/Application/JobApps/Queries/GetAllJobAppsQuery.cs
@@ -32,7 +32,7 @@ namespace Application.JobApps.Queries
 
         public async Task<List<JobApp>> Handle(GetAllJobAppsQuery request, CancellationToken cancellationToken)
         {
-            var applicants = await _context.JobApps.ToListAsync();
+            var applicants = await _context.JobApps.Include(applicant => applicant.Answers).ToListAsync();
 
             if (!request.QualifiedOnly)
             {
@@ -60,8 +60,6 @@ namespace Application.JobApps.Queries
             }).ToList();
 
             return qualifiedApplicants;
-
-            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where get all job apps query handler was getting an argument null exception on LINQ join.

This explicitly includes the `answers` navigation property on the query for applicants.